### PR TITLE
upgrade jaxb2 maven plugin

### DIFF
--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 
 	<properties>
-		<maven-jaxb2-plugin.version>0.8.3</maven-jaxb2-plugin.version>
+		<maven-jaxb2-plugin.version>0.10.0</maven-jaxb2-plugin.version>
 		<build-helper-maven-plugin.version>1.8</build-helper-maven-plugin.version>
 	</properties>
 


### PR DESCRIPTION
Version used in tsb of jaxb2 maven plugin fails after upgrade to java 8.
Latest version of jaxb2 fixes the error.

https://github.com/highsource/maven-jaxb2-plugin/wiki/Configuring-Extension-Validation-and-XML-Security