### PR TITLE
TDS-1163: Feature/delete assessment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 		<sb11-mna-client.version>4.0.3.RELEASE</sb11-mna-client.version>
 		<sb11-shared-code.version>4.0.7</sb11-shared-code.version>
         <sb11-shared-security.version>4.0.4</sb11-shared-security.version>
+		<tds-common-legacy.version>5.0.0.RELEASE</tds-common-legacy.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,14 @@
             <artifactId>mockito-all</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
-        </dependency>       
+        </dependency>
+
+		<dependency>
+			<groupId>com.jayway.jsonpath</groupId>
+			<artifactId>json-path</artifactId>
+			<version>2.4.0</version>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -18,6 +18,13 @@
 	</properties>
 
 	<dependencies>
+		<!-- Shared TDS -->
+		<dependency>
+			<groupId>org.opentestsystem.delivery</groupId>
+			<artifactId>tds-common-legacy</artifactId>
+			<version>${tds-common-legacy.version}</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
@@ -118,7 +125,7 @@
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-sftp</artifactId>
         </dependency>
-        
+
 	</dependencies>
 
 	<build>

--- a/rest/src/main/java/org/opentestsystem/authoring/testspecbank/client/tib/ValidationErrorCode.java
+++ b/rest/src/main/java/org/opentestsystem/authoring/testspecbank/client/tib/ValidationErrorCode.java
@@ -1,0 +1,9 @@
+package org.opentestsystem.authoring.testspecbank.client.tib;
+
+/**
+ * Possible validation error codes returned the code of a {@link tds.common.ValidationError}.
+ */
+public class ValidationErrorCode {
+    public static final String TEST_SPECIFICATION_NOT_FOUND = "notFound";
+    public static final String TEST_SPECIFICATION_EXCEPTION = "internalServerError";
+}

--- a/rest/src/main/java/org/opentestsystem/authoring/testspecbank/persistence/TestSpecificationRepository.java
+++ b/rest/src/main/java/org/opentestsystem/authoring/testspecbank/persistence/TestSpecificationRepository.java
@@ -18,4 +18,5 @@ import org.opentestsystem.shared.search.persistence.SearchableRepository;
  */
 public interface TestSpecificationRepository extends SearchableRepository<TestSpecification, String>, TestSpecificationRepositoryCustom {
     List<TestSpecification> findAllByTenantId(String tenantId);
+    TestSpecification findOneByName(String testSpecificationName);
 }

--- a/rest/src/main/java/org/opentestsystem/authoring/testspecbank/rest/TestSpecificationController.java
+++ b/rest/src/main/java/org/opentestsystem/authoring/testspecbank/rest/TestSpecificationController.java
@@ -10,6 +10,7 @@ package org.opentestsystem.authoring.testspecbank.rest;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
@@ -36,6 +37,9 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+
+import tds.common.ValidationError;
+import tds.common.web.resources.NoContentResponseResource;
 
 /**
  * process test specifications
@@ -108,7 +112,25 @@ public class TestSpecificationController extends AbstractRestController {
         checkWriteAccessForTenant(testSpecificationId);
         return this.testSpecificationService.retireTestSpecification(testSpecificationId, undoRetirement);
     }
-    
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @RequestMapping(value = "/{testSpecificationName}", method = RequestMethod.DELETE, produces = { MediaType.APPLICATION_JSON_VALUE })
+    @Secured({ "ROLE_Test Spec Admin" })
+    @ResponseBody
+    public ResponseEntity<NoContentResponseResource> deleteTestSpecification(@PathVariable final String testSpecificationName) {
+        final Optional<ValidationError> maybeError = testSpecificationService.deleteTestSpecification(testSpecificationName);
+        if (maybeError.isPresent()) {
+            final ValidationError error = maybeError.get();
+            final HttpStatus httpStatus = error.getCode().equalsIgnoreCase("notFound")
+                ? HttpStatus.UNPROCESSABLE_ENTITY
+                : HttpStatus.INTERNAL_SERVER_ERROR;
+
+            return new ResponseEntity<>(new NoContentResponseResource(error), httpStatus);
+        }
+
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
     @ResponseStatus(HttpStatus.OK)
     @RequestMapping(value = "/isAdminUser", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody

--- a/rest/src/main/java/org/opentestsystem/authoring/testspecbank/rest/TestSpecificationController.java
+++ b/rest/src/main/java/org/opentestsystem/authoring/testspecbank/rest/TestSpecificationController.java
@@ -115,7 +115,7 @@ public class TestSpecificationController extends AbstractRestController {
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @RequestMapping(value = "/{testSpecificationName}", method = RequestMethod.DELETE, produces = { MediaType.APPLICATION_JSON_VALUE })
-    @Secured({ "ROLE_Test Spec Admin" })
+    //@Secured({ "ROLE_Test Spec Admin" })
     @ResponseBody
     public ResponseEntity<NoContentResponseResource> deleteTestSpecification(@PathVariable final String testSpecificationName) {
         final Optional<ValidationError> maybeError = testSpecificationService.deleteTestSpecification(testSpecificationName);

--- a/rest/src/main/java/org/opentestsystem/authoring/testspecbank/service/TestSpecificationService.java
+++ b/rest/src/main/java/org/opentestsystem/authoring/testspecbank/service/TestSpecificationService.java
@@ -11,10 +11,13 @@ package org.opentestsystem.authoring.testspecbank.service;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Optional;
 
 import org.opentestsystem.authoring.testspecbank.domain.ExportPackageStatus;
 import org.opentestsystem.authoring.testspecbank.domain.TestSpecification;
 import org.opentestsystem.shared.search.domain.SearchResponse;
+
+import tds.common.ValidationError;
 
 public interface TestSpecificationService {
 
@@ -88,4 +91,12 @@ public interface TestSpecificationService {
      */
     void transferExportPackage(TestSpecification testSpecification);
 
+    /**
+     * Delete a {@link TestSpecification} from the Test Specification Bank.
+     *
+     * @param testSpecificationName The name of the specification to delete.
+     * @return a {@link tds.common.ValidationError} if an error is encountered attempting to delete the test
+     * specification, otherwise {@code Optional.empty()}.
+     */
+    Optional<ValidationError> deleteTestSpecification(final String testSpecificationName);
 }

--- a/rest/src/main/java/org/opentestsystem/authoring/testspecbank/service/impl/TestSpecificationServiceImpl.java
+++ b/rest/src/main/java/org/opentestsystem/authoring/testspecbank/service/impl/TestSpecificationServiceImpl.java
@@ -27,6 +27,7 @@ import javax.xml.transform.stream.StreamSource;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.joda.time.DateTime;
 import org.opentestsystem.authoring.testspecbank.client.tib.TestItemBankClientInterface;
+import org.opentestsystem.authoring.testspecbank.client.tib.ValidationErrorCode;
 import org.opentestsystem.authoring.testspecbank.domain.ExportPackage;
 import org.opentestsystem.authoring.testspecbank.domain.ExportPackageStatus;
 import org.opentestsystem.authoring.testspecbank.domain.MnaAlertType;
@@ -377,7 +378,7 @@ public class TestSpecificationServiceImpl implements TestSpecificationService {
         TestSpecification testSpecification = testSpecificationRepository.findOneByName(testSpecificationName);
         if (testSpecification == null) {
             return Optional.of(
-                new ValidationError("notFound",
+                new ValidationError(ValidationErrorCode.TEST_SPECIFICATION_NOT_FOUND,
                     String.format("Could not find test specification for key '%s'", testSpecificationName)));
         }
 
@@ -385,7 +386,7 @@ public class TestSpecificationServiceImpl implements TestSpecificationService {
             testSpecificationRepository.delete(testSpecification);
             gridFsRepository.delete(testSpecification.getSpecificationXmlGridFsId());
         } catch (final Exception e) {
-            return Optional.of(new ValidationError("exception", e.getMessage()));
+            return Optional.of(new ValidationError(ValidationErrorCode.TEST_SPECIFICATION_EXCEPTION, e.getMessage()));
         }
 
         return Optional.empty();

--- a/rest/src/main/java/org/opentestsystem/authoring/testspecbank/service/impl/TestSpecificationServiceImpl.java
+++ b/rest/src/main/java/org/opentestsystem/authoring/testspecbank/service/impl/TestSpecificationServiceImpl.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
@@ -67,6 +68,8 @@ import com.google.common.collect.Sets;
 import com.mongodb.DBObject;
 import com.mongodb.gridfs.GridFSDBFile;
 import com.mongodb.gridfs.GridFSFile;
+
+import tds.common.ValidationError;
 
 @Service("testSpecificationService")
 public class TestSpecificationServiceImpl implements TestSpecificationService {
@@ -367,6 +370,25 @@ public class TestSpecificationServiceImpl implements TestSpecificationService {
         } catch (final RuntimeException e) {
             handleFailedExport(testSpecification.getId(), e);
         }
+    }
+
+    @Override
+    public Optional<ValidationError> deleteTestSpecification(final String testSpecificationName) {
+        TestSpecification testSpecification = testSpecificationRepository.findOneByName(testSpecificationName);
+        if (testSpecification == null) {
+            return Optional.of(
+                new ValidationError("notFound",
+                    String.format("Could not find test specification for key '%s'", testSpecificationName)));
+        }
+
+        try {
+            testSpecificationRepository.delete(testSpecification);
+            gridFsRepository.delete(testSpecification.getSpecificationXmlGridFsId());
+        } catch (final Exception e) {
+            return Optional.of(new ValidationError("exception", e.getMessage()));
+        }
+
+        return Optional.empty();
     }
 
     /**

--- a/rest/src/test/java/org/opentestsystem/authoring/testspecbank/integration/TestSpecificationServiceTest.java
+++ b/rest/src/test/java/org/opentestsystem/authoring/testspecbank/integration/TestSpecificationServiceTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,15 +26,18 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
+import com.mongodb.gridfs.GridFSDBFile;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.opentestsystem.authoring.testspecbank.client.tib.TestItemBankClientInterface;
+import org.opentestsystem.authoring.testspecbank.client.tib.ValidationErrorCode;
 import org.opentestsystem.authoring.testspecbank.domain.ExportPackageStatus;
 import org.opentestsystem.authoring.testspecbank.domain.Purpose;
 import org.opentestsystem.authoring.testspecbank.domain.TestSpecification;
@@ -43,6 +47,8 @@ import org.opentestsystem.authoring.testspecbank.domain.search.TestSpecification
 import org.opentestsystem.authoring.testspecbank.domain.tib.ExportItemClientObj;
 import org.opentestsystem.authoring.testspecbank.domain.tib.ExportSetClientObj;
 import org.opentestsystem.authoring.testspecbank.domain.tib.ExportStatus;
+import org.opentestsystem.authoring.testspecbank.persistence.GridFsRepository;
+import org.opentestsystem.authoring.testspecbank.persistence.GridFsRepositoryImpl;
 import org.opentestsystem.authoring.testspecbank.persistence.TestSpecificationRepository;
 import org.opentestsystem.authoring.testspecbank.rest.AbstractRestEmbeddedMongoTest;
 import org.opentestsystem.authoring.testspecbank.service.FileManagerService;
@@ -58,6 +64,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import tds.common.ValidationError;
+
 public class TestSpecificationServiceTest extends AbstractRestEmbeddedMongoTest {
 
     @Autowired
@@ -65,6 +73,9 @@ public class TestSpecificationServiceTest extends AbstractRestEmbeddedMongoTest 
 
     @Autowired
     private TestSpecificationRepository testSpecificationRepository;
+
+    @Autowired
+    private GridFsRepository gridFsRepository;
 
     @Autowired
     private FileTransferService testItemBankFileTransferService; // mock
@@ -532,6 +543,49 @@ public class TestSpecificationServiceTest extends AbstractRestEmbeddedMongoTest 
         } catch (final LocalizedException e) {
             assertThat(e.getMessage(), is("testspec.retired.export"));
         }
+    }
+
+    @Test
+    public void shouldDeleteATestSpecification() {
+        final TestSpecification testSpecificationToDelete = PODAM_FACTORY.manufacturePojo(TestSpecification.class);
+        testSpecificationToDelete.setId(null);
+        testSpecificationToDelete.setLastUpdatedDate(null);
+        testSpecificationToDelete.setSpecificationXml(TestSpecificationXmlBuilder.generateXml(TestSpecificationXmlBuilder.buildValidTestspecification(Purpose.SCORING)));
+        final TestSpecification savedTestSpecificationToDelete = this.testSpecificationService.saveTestSpecification(testSpecificationToDelete);
+        assertThat(savedTestSpecificationToDelete, is(notNullValue()));
+
+        final TestSpecification testSpecificationToRemain = PODAM_FACTORY.manufacturePojo(TestSpecification.class);
+        testSpecificationToRemain.setId(null);
+        testSpecificationToRemain.setLastUpdatedDate(null);
+        testSpecificationToRemain.setSpecificationXml(TestSpecificationXmlBuilder.generateXml(TestSpecificationXmlBuilder.buildValidTestspecification(Purpose.SCORING)));
+        testSpecificationRepository.save(testSpecificationToRemain);
+
+        testSpecificationService.deleteTestSpecification(testSpecificationToDelete.getName());
+
+        final TestSpecification foundSpecification = testSpecificationRepository.findOneByName(testSpecificationToDelete.getName());
+        assertThat(foundSpecification, is(nullValue()));
+        final GridFSDBFile foundGridFsFile = gridFsRepository.getById(testSpecificationToDelete.getSpecificationXmlGridFsId());
+        assertThat(foundGridFsFile, is(nullValue()));
+
+        final TestSpecification foundSpecificationThatShouldRemain = testSpecificationRepository.findOneByName(testSpecificationToRemain.getName());
+        assertThat(foundSpecificationThatShouldRemain, is(not(nullValue())));
+    }
+
+    @Test
+    public void shouldReturnValidationErrorWhenDeletingTestSpecificationThatCannotBeFound() {
+        final TestSpecification testSpecificationToDelete = PODAM_FACTORY.manufacturePojo(TestSpecification.class);
+        testSpecificationToDelete.setId(null);
+        testSpecificationToDelete.setLastUpdatedDate(null);
+        testSpecificationToDelete.setSpecificationXml(TestSpecificationXmlBuilder.generateXml(TestSpecificationXmlBuilder.buildValidTestspecification(Purpose.SCORING)));
+        final TestSpecification savedTestSpecificationToDelete = this.testSpecificationService.saveTestSpecification(testSpecificationToDelete);
+        assertThat(savedTestSpecificationToDelete, is(notNullValue()));
+
+        final Optional<ValidationError> maybeError = testSpecificationService.deleteTestSpecification("a name that does not exist");
+
+        assertThat(maybeError.isPresent(), is(true));
+        final ValidationError error = maybeError.get();
+        assertThat(error.getCode(), is(ValidationErrorCode.TEST_SPECIFICATION_NOT_FOUND));
+        assertThat(error.getMessage(), is("Could not find test specification for key 'a name that does not exist'"));
     }
 
     private static TestSpecification buildTestSpecificationWithExportPackage(final ExportPackageStatus status, final boolean decompressXml) {

--- a/rest/src/test/java/org/opentestsystem/authoring/testspecbank/rest/TestSpecificationControllerTest.java
+++ b/rest/src/test/java/org/opentestsystem/authoring/testspecbank/rest/TestSpecificationControllerTest.java
@@ -14,8 +14,11 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +38,7 @@ import org.opentestsystem.shared.exception.RestException;
 import org.opentestsystem.shared.search.domain.SearchResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -42,6 +46,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import org.springframework.web.util.UriComponentsBuilder;
 
 public class TestSpecificationControllerTest extends AbstractRestEmbeddedMongoTest {
 
@@ -264,6 +269,34 @@ public class TestSpecificationControllerTest extends AbstractRestEmbeddedMongoTe
         response = callGETRestService("/testSpecification" + buildQueryString(params), SearchResponse.class);
         assertThat(response.getReturnCount(), is(1));
         assertThat(response.getSearchResults().size(), is(1));
+    }
+
+    @ApiDocExample(rank = -1)
+    @Test
+    public void deleteTestSpecification() throws Exception {
+        URI uri = UriComponentsBuilder.fromUriString(String.format("/testSpecification/%s", savedTestSpecification.getName()))
+            .build()
+            .toUri();
+
+        mockMvc.perform(delete(uri)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent());
+    }
+
+    @ApiDocExample(rank = -1)
+    @Test
+    public void shouldReturnUnprocessableEntityWhenAttemptingToDeleteAssessmentThatIsNotFound() throws Exception {
+        URI uri = UriComponentsBuilder.fromUriString(String.format("/testSpecification/i-do-not-exist"))
+            .build()
+            .toUri();
+
+        mockMvc.perform(delete(uri)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(jsonPath("errors").isNotEmpty())
+            .andExpect(jsonPath("errors").isArray())
+            .andExpect(jsonPath("errors[0].code", is("notFound")))
+            .andExpect(jsonPath("errors[0].message", is("Could not find test specification for key 'i-do-not-exist'")));
     }
 
     private Map<String, Object> buildTestSpecificationMap(final int uniqueId, final Purpose purpose) {


### PR DESCRIPTION
[TDS-1163](https://jira.fairwaytech.com/browse/TDS-1163):  Delete an assessment from Test Specification Bank (TSB).

**NOTE:** Right now, the `DELETE` endpoint has no security.  This is by design; as we approach completion of the support tool, security will be enabled (that is, the `@Secured` annotation will be un-commented).