### PR TITLE
Feature/load assessment

### DIFF
--- a/client/src/main/java/org/opentestsystem/authoring/testspecbank/client/TestSpecBankClient.java
+++ b/client/src/main/java/org/opentestsystem/authoring/testspecbank/client/TestSpecBankClient.java
@@ -170,7 +170,7 @@ public class TestSpecBankClient implements TestSpecBankClientInterface {
 
     @Override
     public TestSpecBankClientObj publishTestSpecification(final TestSpecBankClientObj testSpecification) {
-        final ResponseEntity<TestSpecBankClientObj> response = this.tsbRestTemplate.postForEntity(this.baseUri + "testSpecification", testSpecification, TestSpecBankClientObj.class);
+        final ResponseEntity<TestSpecBankClientObj> response = this.tsbOauthRestTemplate.postForEntity(this.baseUri + "testSpecification", testSpecification, TestSpecBankClientObj.class);
         return response.getBody();
     }
 }

--- a/rest/src/main/java/org/opentestsystem/authoring/testspecbank/service/impl/TestSpecificationServiceImpl.java
+++ b/rest/src/main/java/org/opentestsystem/authoring/testspecbank/service/impl/TestSpecificationServiceImpl.java
@@ -112,6 +112,10 @@ public class TestSpecificationServiceImpl implements TestSpecificationService {
         }
         TestSpecification savedTestSpecification = null;
         try {
+            if (Boolean.valueOf(this.testSpecDtdValidation)) {
+                final byte[] decompressedXml = decompress(testSpecification.getSpecificationXml());
+                validateXmlWithDtd(decompressedXml);
+            }
             Assert.isNull(testSpecification.getLastUpdatedDate());
             testSpecification.setLastUpdatedDate(new DateTime());
             testSpecification.setTenantSet(Sets.newHashSet(testSpecification.getTenantId()));

--- a/rest/src/main/java/org/opentestsystem/authoring/testspecbank/service/impl/TestSpecificationServiceImpl.java
+++ b/rest/src/main/java/org/opentestsystem/authoring/testspecbank/service/impl/TestSpecificationServiceImpl.java
@@ -115,6 +115,18 @@ public class TestSpecificationServiceImpl implements TestSpecificationService {
             Assert.isNull(testSpecification.getLastUpdatedDate());
             testSpecification.setLastUpdatedDate(new DateTime());
             testSpecification.setTenantSet(Sets.newHashSet(testSpecification.getTenantId()));
+
+            if (testSpecification.getSpecificationXml() != null) {
+                if (Boolean.valueOf(this.testSpecDtdValidation)) {
+                    final byte[] decompressedXml = decompress(testSpecification.getSpecificationXml());
+                    validateXmlWithDtd(decompressedXml);
+                    final DBObject metadata = new GridFSDBFile();
+                    metadata.put("contentType", "application/xml");
+                    final GridFSFile gridFsFile = this.gridFsRepository.save(testSpecification.getSpecificationXml(), generateGridFsFilename(testSpecification), metadata);
+                    testSpecification.setSpecificationXmlGridFsId(gridFsFile.getId().toString());
+                }
+            }
+
             savedTestSpecification = this.testSpecificationRepository.save(testSpecification);
             final String message = "Test Specification successfully stored; name: " + testSpecification.getName() + ", version: " + testSpecification.getVersion();
             this.alertBeacon.sendAlert(MnaSeverity.INFO, MnaAlertType.TEST_SPEC_SAVED.name(), message);
@@ -369,7 +381,9 @@ public class TestSpecificationServiceImpl implements TestSpecificationService {
         }
 
         testSpecificationRepository.delete(testSpecification);
-        gridFsRepository.delete(testSpecification.getSpecificationXmlGridFsId());
+        if (testSpecification.getSpecificationXmlGridFsId() != null) {
+            gridFsRepository.delete(testSpecification.getSpecificationXmlGridFsId());
+        }
 
         return Optional.empty();
     }

--- a/rest/src/main/java/org/opentestsystem/authoring/testspecbank/service/impl/TestSpecificationServiceImpl.java
+++ b/rest/src/main/java/org/opentestsystem/authoring/testspecbank/service/impl/TestSpecificationServiceImpl.java
@@ -110,25 +110,13 @@ public class TestSpecificationServiceImpl implements TestSpecificationService {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Saving TestSpecification; TestSpecifcation: " + testSpecification.toString());
         }
-        if (testSpecification.getSpecificationXml() == null) {
-            throw new LocalizedException("testspec.spec.xml.required");
-        }
         TestSpecification savedTestSpecification = null;
         try {
-            if (Boolean.valueOf(this.testSpecDtdValidation)) {
-                final byte[] decompressedXml = decompress(testSpecification.getSpecificationXml());
-                validateXmlWithDtd(decompressedXml);
-            }
             Assert.isNull(testSpecification.getLastUpdatedDate());
             testSpecification.setLastUpdatedDate(new DateTime());
             testSpecification.setTenantSet(Sets.newHashSet(testSpecification.getTenantId()));
-            final DBObject metadata = new GridFSDBFile();
-            metadata.put("contentType", "application/xml");
-            final GridFSFile gridFsFile = this.gridFsRepository.save(testSpecification.getSpecificationXml(), generateGridFsFilename(testSpecification), metadata);
-            testSpecification.setSpecificationXmlGridFsId(gridFsFile.getId().toString());
             savedTestSpecification = this.testSpecificationRepository.save(testSpecification);
-            final String message = "Test Specification successfully stored; name: " + testSpecification.getName() + ", version: " + testSpecification.getVersion() + ", filename: "
-                + gridFsFile.getFilename();
+            final String message = "Test Specification successfully stored; name: " + testSpecification.getName() + ", version: " + testSpecification.getVersion();
             this.alertBeacon.sendAlert(MnaSeverity.INFO, MnaAlertType.TEST_SPEC_SAVED.name(), message);
         } catch (final Exception e) {
             final Map<String, String[]> parameterMap = ImmutableMap.of(

--- a/rest/src/test/java/org/opentestsystem/authoring/testspecbank/integration/TestSpecificationServiceTest.java
+++ b/rest/src/test/java/org/opentestsystem/authoring/testspecbank/integration/TestSpecificationServiceTest.java
@@ -163,7 +163,7 @@ public class TestSpecificationServiceTest extends AbstractRestEmbeddedMongoTest 
         assertThat(searchResponse.getSearchResults().size(), is(1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = LocalizedException.class)
     public void saveInvalidTestSpecificationXmlThrowsErrorTest() {
         assertThat(ReflectionTestUtils.getField(this.testSpecificationService, "testSpecDtdUrl"), is(notNullValue()));
         final TestSpecification testSpecificationToSave = PODAM_FACTORY.manufacturePojo(TestSpecification.class);

--- a/rest/src/test/java/org/opentestsystem/authoring/testspecbank/integration/TestSpecificationServiceTest.java
+++ b/rest/src/test/java/org/opentestsystem/authoring/testspecbank/integration/TestSpecificationServiceTest.java
@@ -163,7 +163,7 @@ public class TestSpecificationServiceTest extends AbstractRestEmbeddedMongoTest 
         assertThat(searchResponse.getSearchResults().size(), is(1));
     }
 
-    @Test(expected = LocalizedException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void saveInvalidTestSpecificationXmlThrowsErrorTest() {
         assertThat(ReflectionTestUtils.getField(this.testSpecificationService, "testSpecDtdUrl"), is(notNullValue()));
         final TestSpecification testSpecificationToSave = PODAM_FACTORY.manufacturePojo(TestSpecification.class);


### PR DESCRIPTION
Making the saving of the specificationXml optional. This is a compress + base 64 encrypted blob of data that stuffed into mongo. We will no longer be reading this blob in in ART.